### PR TITLE
Fixed an issue with loading controllers

### DIFF
--- a/mageploy.php
+++ b/mageploy.php
@@ -44,12 +44,22 @@ class Mage_Shell_Mageploy extends Mage_Shell_Abstract {
     }
 
     protected function _getControllerClassPath($controllerModule, $controllerName) {
+        $moduleParts = explode('_', $controllerModule);
+        $realModule = implode('_', array_splice($moduleParts, 0, 2));
+        $file = Mage::getModuleDir('controllers', $realModule);
+
+        if (count($moduleParts)) {
+            $file .= DS . implode(DS, $moduleParts);
+        }
+
         $parts = explode('_', uc_words($controllerName));
-        $file = Mage::getModuleDir('controllers', $controllerModule);
+
         if (count($parts)) {
             $file .= DS . implode(DS, $parts);
         }
+
         $file .= 'Controller.php';
+
         return $file;
     }
 


### PR DESCRIPTION
Controllers that are overwritten with config layouts are not loaded correctly. For example, the Enterprise_Cms module uses this:

```
<admin>
    <routers>
        <adminhtml>
            <args>
                <modules>
                    <enterprise_cms before="Mage_Adminhtml">Enterprise_Cms_Adminhtml</enterprise_cms>
                </modules>
            </args>
        </adminhtml>
    </routers>
</admin>
```

This causes "Enterprise_Cms_Adminhtml" to be saved as the module, but mageploy will fail to load that, since there isn't actually a module called "Enterprise_Cms_Adminhtml".

The patch addresses that issue, though there may be better ways of handling the problem? I tested the fix with a couple of the built in trackers and it seemed to work fine.
