### PR TITLE
#23 Model/Action->match: compare module name to config value (admin frontName) instead of 'admin'

### DIFF
--- a/Mageploy/Model/Action/Catalog/Product/Attribute.php
+++ b/Mageploy/Model/Action/Catalog/Product/Attribute.php
@@ -60,7 +60,7 @@ class PugMoRe_Mageploy_Model_Action_Catalog_Product_Attribute extends PugMoRe_Ma
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'catalog_product_attribute') {
                 if (in_array($this->_request->getActionName(), array(/* 'validate', */'save', 'delete'))) {
                     return true;

--- a/Mageploy/Model/Action/Catalog/Product/AttributeSet.php
+++ b/Mageploy/Model/Action/Catalog/Product/AttributeSet.php
@@ -29,7 +29,7 @@ class PugMoRe_Mageploy_Model_Action_Catalog_Product_AttributeSet extends PugMoRe
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'catalog_product_set') {
                 if (in_array($this->_request->getActionName(), array(/* 'validate', */'save', 'delete'))) {
                     return true;

--- a/Mageploy/Model/Action/Cms/Block.php
+++ b/Mageploy/Model/Action/Cms/Block.php
@@ -21,7 +21,7 @@ class PugMoRe_Mageploy_Model_Action_Cms_Block extends PugMoRe_Mageploy_Model_Act
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'cms_block') {
                 if (in_array($this->_request->getActionName(), array('save', 'delete'))) {
                     return true;

--- a/Mageploy/Model/Action/Cms/Page.php
+++ b/Mageploy/Model/Action/Cms/Page.php
@@ -21,7 +21,7 @@ class PugMoRe_Mageploy_Model_Action_Cms_Page extends PugMoRe_Mageploy_Model_Acti
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'cms_page') {
                 if (in_array($this->_request->getActionName(), array('save', 'delete'))) {
                     return true;

--- a/Mageploy/Model/Action/Store/Group.php
+++ b/Mageploy/Model/Action/Store/Group.php
@@ -24,7 +24,7 @@ class PugMoRe_Mageploy_Model_Action_Store_Group extends PugMoRe_Mageploy_Model_A
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'system_store') {
                 if (in_array($this->_request->getActionName(), array('deleteGroupPost'))) {
                     return true;

--- a/Mageploy/Model/Action/Store/StoreView.php
+++ b/Mageploy/Model/Action/Store/StoreView.php
@@ -21,7 +21,7 @@ class PugMoRe_Mageploy_Model_Action_Store_StoreView extends PugMoRe_Mageploy_Mod
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'system_store') {
                 if (in_array($this->_request->getActionName(), array('deleteStorePost'))) {
                     return true;

--- a/Mageploy/Model/Action/Store/Website.php
+++ b/Mageploy/Model/Action/Store/Website.php
@@ -21,7 +21,7 @@ class PugMoRe_Mageploy_Model_Action_Store_Website extends PugMoRe_Mageploy_Model
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'system_store') {
                 if (in_array($this->_request->getActionName(), array('deleteWebsitePost'))) {
                     return true;

--- a/Mageploy/Model/Action/System/Config.php
+++ b/Mageploy/Model/Action/System/Config.php
@@ -21,7 +21,7 @@ class PugMoRe_Mageploy_Model_Action_System_Config extends PugMoRe_Mageploy_Model
             return false;
         }
 
-        if ($this->_request->getModuleName() == 'admin') {
+        if ($this->_request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName')) {
             if ($this->_request->getControllerName() == 'system_config') {
                 if (in_array($this->_request->getActionName(), array('save'))) {
                     return true;


### PR DESCRIPTION
I found out that in some Magento installs, Mageploy wasn't tracking changes, even it told "tracking active".
After debugging the code, I found out, that it's not working on installs, where I have changed the path to  admin panel.
I fixed this by reading the admin panel frontName from config instead of comparing the module name to 'admin'. This was necessary in all but one action models.